### PR TITLE
用context替换掉config的全局变量

### DIFF
--- a/src/core/__tests__/config.test.js
+++ b/src/core/__tests__/config.test.js
@@ -194,19 +194,19 @@ describe('Config#init', () => {
     log_max_days: 30
   };
 
-  it('should ctx set correctly', () => {
-    const ctx = new Config(clientConf);
-    expect(ctx.LOCAL_PROTOCOL).toBe('tcp');
-    expect(ctx.LOCAL_HOST).toBe('localhost');
-    expect(ctx.LOCAL_PORT).toBe(1080);
-    expect(ctx.IS_CLIENT).toBe(true);
-    expect(ctx.IS_SERVER).toBe(false);
-    expect(ctx.SERVERS.length).toBe(1);
-    expect(ctx.TIMEOUT).toBe(600 * 1e3);
-    expect(ctx.WORKERS).toBe(0);
-    expect(ctx.LOG_LEVEL).toBe('warn');
-    expect(ctx.LOG_PATH.endsWith('blinksocks.log')).toBe(true);
-    expect(ctx.LOG_MAX_DAYS).toBe(30);
+  it('should config set correctly', () => {
+    const config = new Config(clientConf);
+    expect(config.local_protocol).toBe('tcp');
+    expect(config.local_host).toBe('localhost');
+    expect(config.local_port).toBe(1080);
+    expect(config.is_client).toBe(true);
+    expect(config.is_server).toBe(false);
+    expect(config.servers.length).toBe(1);
+    expect(config.timeout).toBe(600 * 1e3);
+    expect(config.workers).toBe(0);
+    expect(config.log_level).toBe('warn');
+    expect(config.log_path.endsWith('blinksocks.log')).toBe(true);
+    expect(config.log_max_days).toBe(30);
   });
 
 });
@@ -223,11 +223,11 @@ describe('Config#initServer', () => {
     tls_key: 'mock_key.pem'
   };
 
-  it('should ctx set correctly', () => {
-    const ctx = new Config(serverConf);
-    expect(ctx.TRANSPORT).toBe('tls');
-    expect(ctx.TLS_CERT).toBeDefined();
-    expect(ctx.TLS_KEY).toBeDefined();
+  it('should config set correctly', () => {
+    const config = new Config(serverConf);
+    expect(config.transport).toBe('tls');
+    expect(config.tls_cert).toBeDefined();
+    expect(config.tls_key).toBeDefined();
   });
 
 });

--- a/src/core/__tests__/config.test.js
+++ b/src/core/__tests__/config.test.js
@@ -195,7 +195,7 @@ describe('Config#init', () => {
   };
 
   it('should ctx set correctly', () => {
-    const ctx = Config.init(clientConf);
+    const ctx = new Config(clientConf);
     expect(ctx.LOCAL_PROTOCOL).toBe('tcp');
     expect(ctx.LOCAL_HOST).toBe('localhost');
     expect(ctx.LOCAL_PORT).toBe(1080);
@@ -223,8 +223,8 @@ describe('Config#initServer', () => {
     tls_key: 'mock_key.pem'
   };
 
-  it('should globals set correctly', () => {
-    const ctx = Config.init(serverConf);
+  it('should ctx set correctly', () => {
+    const ctx = new Config(serverConf);
     expect(ctx.TRANSPORT).toBe('tls');
     expect(ctx.TLS_CERT).toBeDefined();
     expect(ctx.TLS_KEY).toBeDefined();

--- a/src/core/__tests__/config.test.js
+++ b/src/core/__tests__/config.test.js
@@ -194,19 +194,19 @@ describe('Config#init', () => {
     log_max_days: 30
   };
 
-  it('should globals set correctly', () => {
-    Config.init(clientConf);
-    expect(__LOCAL_PROTOCOL__).toBe('tcp');
-    expect(__LOCAL_HOST__).toBe('localhost');
-    expect(__LOCAL_PORT__).toBe(1080);
-    expect(__IS_CLIENT__).toBe(true);
-    expect(__IS_SERVER__).toBe(false);
-    expect(__SERVERS__.length).toBe(1);
-    expect(__TIMEOUT__).toBe(600 * 1e3);
-    expect(__WORKERS__).toBe(0);
-    expect(__LOG_LEVEL__).toBe('warn');
-    expect(__LOG_PATH__.endsWith('blinksocks.log')).toBe(true);
-    expect(__LOG_MAX_DAYS__).toBe(30);
+  it('should ctx set correctly', () => {
+    const ctx = Config.init(clientConf);
+    expect(ctx.LOCAL_PROTOCOL).toBe('tcp');
+    expect(ctx.LOCAL_HOST).toBe('localhost');
+    expect(ctx.LOCAL_PORT).toBe(1080);
+    expect(ctx.IS_CLIENT).toBe(true);
+    expect(ctx.IS_SERVER).toBe(false);
+    expect(ctx.SERVERS.length).toBe(1);
+    expect(ctx.TIMEOUT).toBe(600 * 1e3);
+    expect(ctx.WORKERS).toBe(0);
+    expect(ctx.LOG_LEVEL).toBe('warn');
+    expect(ctx.LOG_PATH.endsWith('blinksocks.log')).toBe(true);
+    expect(ctx.LOG_MAX_DAYS).toBe(30);
   });
 
 });
@@ -224,10 +224,10 @@ describe('Config#initServer', () => {
   };
 
   it('should globals set correctly', () => {
-    Config.init(serverConf);
-    expect(__TRANSPORT__).toBe('tls');
-    expect(__TLS_CERT__).toBeDefined();
-    expect(__TLS_KEY__).toBeDefined();
+    const ctx = Config.init(serverConf);
+    expect(ctx.TRANSPORT).toBe('tls');
+    expect(ctx.TLS_CERT).toBeDefined();
+    expect(ctx.TLS_KEY).toBeDefined();
   });
 
 });

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -15,8 +15,8 @@ function loadFileSync(file) {
 }
 
 export class Config {
-
-  static init(json) {
+  constructor(json){
+  // static init(json) {
     const ctx = {};
     const {protocol, hostname, port, query} = url.parse(json.service);
     ctx.LOCAL_PROTOCOL = protocol.slice(0, -1);

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -16,7 +16,6 @@ function loadFileSync(file) {
 
 export class Config {
   constructor(json){
-  // static init(json) {
     const ctx = {};
     const {protocol, hostname, port, query} = url.parse(json.service);
     ctx.LOCAL_PROTOCOL = protocol.slice(0, -1);

--- a/src/core/hub.js
+++ b/src/core/hub.js
@@ -38,7 +38,7 @@ export class Hub {
   _ctx = null;
 
   constructor(config) {
-    this._ctx = Config.init(config);
+    this._ctx = new Config(config);
     this._onConnection = this._onConnection.bind(this);
     this._udpRelays = LRU({
       max: 500,

--- a/src/core/middleware.js
+++ b/src/core/middleware.js
@@ -5,12 +5,13 @@ import {kebabCase} from '../utils';
 
 const staticPresetCache = new Map(/* 'ClassName': <preset> */);
 
-function createPreset(name, params = {}, ctx) {
+function createPreset(name, params = {}, config) {
   const ImplClass = getPresetClassByName(name);
   const createOne = () => {
-    ImplClass.checkParams(params, ctx);
-    ImplClass.onInit(params, ctx);
-    return new ImplClass(params, ctx);
+    ImplClass.config = config;
+    ImplClass.checkParams(params);
+    ImplClass.onInit(params);
+    return new ImplClass(params);
   };
   let preset = null;
   if (IPresetStatic.isPrototypeOf(ImplClass)) {
@@ -32,16 +33,15 @@ function createPreset(name, params = {}, ctx) {
 export class Middleware extends EventEmitter {
 
   _impl = null;
-  _ctx = null;
+  _config = null;
 
-  constructor(preset, ctx) {
+  constructor(preset, config) {
     super();
-    console.log(this._ctx)
-    this._ctx = ctx;
+    this._config = config;
     this.onPresetNext = this.onPresetNext.bind(this);
     this.onPresetBroadcast = this.onPresetBroadcast.bind(this);
     this.onPresetFail = this.onPresetFail.bind(this);
-    this._impl = createPreset(preset.name, preset.params || {}, this._ctx);
+    this._impl = createPreset(preset.name, preset.params || {}, this._config);
     this._impl.next = this.onPresetNext;
     this._impl.broadcast = this.onPresetBroadcast;
     this._impl.fail = this.onPresetFail;
@@ -108,7 +108,7 @@ export class Middleware extends EventEmitter {
     // clientXXX, serverXXX
     const nextLifeCycleHook = (buf/* , isReverse = false */) => {
       const args = {buffer: buf, next, broadcast, direct, fail};
-      const ret = this._ctx.IS_CLIENT ? this._impl[`client${type}`](args, extraArgs) : this._impl[`server${type}`](args, extraArgs);
+      const ret = this._config.is_client ? this._impl[`client${type}`](args, extraArgs) : this._impl[`server${type}`](args, extraArgs);
       if (ret instanceof Buffer) {
         next(ret);
       }

--- a/src/core/mux-relay.js
+++ b/src/core/mux-relay.js
@@ -28,7 +28,7 @@ export class MuxRelay extends Relay {
       'tls': [TlsInbound, TlsOutbound],
       'ws': [WsInbound, WsOutbound],
     };
-    const [Inbound, Outbound] = this._globalCtx.IS_CLIENT ? [MuxInbound, mapping[transport][1]] : [mapping[transport][0], MuxOutbound];
+    const [Inbound, Outbound] = this._config.is_client ? [MuxInbound, mapping[transport][1]] : [mapping[transport][0], MuxOutbound];
     return {Inbound, Outbound};
   }
 
@@ -121,7 +121,7 @@ export class MuxRelay extends Relay {
       logger.error(`[mux-${this.id}] fail to dispatch data frame(size=${data.length}), no such sub connection(cid=${cid})`);
       return;
     }
-    if (this._globalCtx.IS_CLIENT || relay.isOutboundReady()) {
+    if (this._config.is_client || relay.isOutboundReady()) {
       relay.decode(data);
     } else {
       // TODO: find a way to avoid using relay._pendingFrames

--- a/src/core/mux-relay.js
+++ b/src/core/mux-relay.js
@@ -28,7 +28,7 @@ export class MuxRelay extends Relay {
       'tls': [TlsInbound, TlsOutbound],
       'ws': [WsInbound, WsOutbound],
     };
-    const [Inbound, Outbound] = __IS_CLIENT__ ? [MuxInbound, mapping[transport][1]] : [mapping[transport][0], MuxOutbound];
+    const [Inbound, Outbound] = this._globalCtx.IS_CLIENT ? [MuxInbound, mapping[transport][1]] : [mapping[transport][0], MuxOutbound];
     return {Inbound, Outbound};
   }
 
@@ -121,7 +121,7 @@ export class MuxRelay extends Relay {
       logger.error(`[mux-${this.id}] fail to dispatch data frame(size=${data.length}), no such sub connection(cid=${cid})`);
       return;
     }
-    if (__IS_CLIENT__ || relay.isOutboundReady()) {
+    if (this._globalCtx.IS_CLIENT || relay.isOutboundReady()) {
       relay.decode(data);
     } else {
       // TODO: find a way to avoid using relay._pendingFrames

--- a/src/core/pipe.js
+++ b/src/core/pipe.js
@@ -21,7 +21,7 @@ export class Pipe extends EventEmitter {
 
   _presets = null;
   
-  _ctx = null;
+  _config = null;
 
   get destroyed() {
     return this._destroyed;
@@ -31,9 +31,9 @@ export class Pipe extends EventEmitter {
     return this._presets;
   }
 
-  constructor({presets, isUdp = false}, ctx) {
+  constructor({presets, isUdp = false}, config) {
     super();
-    this._ctx = ctx;
+    this._config = config;
     this.broadcast = this.broadcast.bind(this);
     this.onReadProperty = this.onReadProperty.bind(this);
     this.createMiddlewares(presets);
@@ -143,7 +143,7 @@ export class Pipe extends EventEmitter {
   }
 
   _createMiddleware(preset) {
-    const middleware = new Middleware(preset, this._ctx);
+    const middleware = new Middleware(preset, this._config);
     this._attachEvents(middleware);
     // set readProperty()
     const impl = middleware.getImplement();

--- a/src/core/pipe.js
+++ b/src/core/pipe.js
@@ -20,6 +20,8 @@ export class Pipe extends EventEmitter {
   _destroyed = false;
 
   _presets = null;
+  
+  _ctx = null;
 
   get destroyed() {
     return this._destroyed;
@@ -29,8 +31,9 @@ export class Pipe extends EventEmitter {
     return this._presets;
   }
 
-  constructor({presets, isUdp = false}) {
+  constructor({presets, isUdp = false}, ctx) {
     super();
+    this._ctx = ctx;
     this.broadcast = this.broadcast.bind(this);
     this.onReadProperty = this.onReadProperty.bind(this);
     this.createMiddlewares(presets);
@@ -140,7 +143,7 @@ export class Pipe extends EventEmitter {
   }
 
   _createMiddleware(preset) {
-    const middleware = new Middleware(preset);
+    const middleware = new Middleware(preset, this._ctx);
     this._attachEvents(middleware);
     // set readProperty()
     const impl = middleware.getImplement();

--- a/src/presets/aead-random-cipher.js
+++ b/src/presets/aead-random-cipher.js
@@ -118,11 +118,11 @@ export default class AeadRandomCipherPreset extends IPreset {
     }
   }
 
-  static onInit({method, info = DEFAULT_INFO, factor = DEFAULT_FACTOR}, {KEY}) {
+  static onInit({method, info = DEFAULT_INFO, factor = DEFAULT_FACTOR}) {
     AeadRandomCipherPreset.cipherName = method;
     AeadRandomCipherPreset.info = Buffer.from(info);
     AeadRandomCipherPreset.factor = factor;
-    AeadRandomCipherPreset.rawKey = Buffer.from(KEY);
+    AeadRandomCipherPreset.rawKey = Buffer.from(AeadRandomCipherPreset.config.key);
     AeadRandomCipherPreset.keySaltSize = ciphers[method];
   }
 

--- a/src/presets/aead-random-cipher.js
+++ b/src/presets/aead-random-cipher.js
@@ -118,11 +118,11 @@ export default class AeadRandomCipherPreset extends IPreset {
     }
   }
 
-  static onInit({method, info = DEFAULT_INFO, factor = DEFAULT_FACTOR}) {
+  static onInit({method, info = DEFAULT_INFO, factor = DEFAULT_FACTOR}, {KEY}) {
     AeadRandomCipherPreset.cipherName = method;
     AeadRandomCipherPreset.info = Buffer.from(info);
     AeadRandomCipherPreset.factor = factor;
-    AeadRandomCipherPreset.rawKey = Buffer.from(__KEY__);
+    AeadRandomCipherPreset.rawKey = Buffer.from(KEY);
     AeadRandomCipherPreset.keySaltSize = ciphers[method];
   }
 

--- a/src/presets/auto-conf.js
+++ b/src/presets/auto-conf.js
@@ -76,19 +76,12 @@ export default class AutoConfPreset extends IPreset {
 
   _header = null;
 
-  _ctx = null;
-
   static suites = [];
 
   static checkParams({suites}) {
     if (typeof suites !== 'string' || suites.length < 1) {
       throw Error('\'suites\' is invalid');
     }
-  }
-
-  constructor(_, ctx) {
-    super();
-    this._ctx = ctx;
   }
 
   static async onInit({suites: uri}) {
@@ -118,7 +111,7 @@ export default class AutoConfPreset extends IPreset {
   createRequestHeader(suites) {
     const sid = crypto.randomBytes(2);
     const utc = ntb(getCurrentTimestampInt(), 4, BYTE_ORDER_LE);
-    const key = EVP_BytesToKey(Buffer.from(this._ctx.KEY).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
+    const key = EVP_BytesToKey(Buffer.from(AutoConfPreset.config.key).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
     const cipher = crypto.createCipheriv('rc4', key, NOOP);
     const enc_utc = cipher.update(utc);
     const request_hmac = hmac('md5', key, Buffer.concat([sid, enc_utc]));
@@ -156,7 +149,7 @@ export default class AutoConfPreset extends IPreset {
     }
     const sid = buffer.slice(0, 2);
     const request_hmac = buffer.slice(6, 22);
-    const key = EVP_BytesToKey(Buffer.from(this._ctx.KEY).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
+    const key = EVP_BytesToKey(Buffer.from(AutoConfPreset.config.KEY).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
     const hmac_calc = hmac('md5', key, buffer.slice(0, 6));
     if (!hmac_calc.equals(request_hmac)) {
       return fail(`unexpected hmac of client request, dump=${dumpHex(buffer)}`);

--- a/src/presets/auto-conf.js
+++ b/src/presets/auto-conf.js
@@ -76,12 +76,19 @@ export default class AutoConfPreset extends IPreset {
 
   _header = null;
 
+  _ctx = null;
+
   static suites = [];
 
   static checkParams({suites}) {
     if (typeof suites !== 'string' || suites.length < 1) {
       throw Error('\'suites\' is invalid');
     }
+  }
+
+  constructor(_, ctx) {
+    super();
+    this._ctx = ctx;
   }
 
   static async onInit({suites: uri}) {
@@ -111,7 +118,7 @@ export default class AutoConfPreset extends IPreset {
   createRequestHeader(suites) {
     const sid = crypto.randomBytes(2);
     const utc = ntb(getCurrentTimestampInt(), 4, BYTE_ORDER_LE);
-    const key = EVP_BytesToKey(Buffer.from(__KEY__).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
+    const key = EVP_BytesToKey(Buffer.from(this._ctx.KEY).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
     const cipher = crypto.createCipheriv('rc4', key, NOOP);
     const enc_utc = cipher.update(utc);
     const request_hmac = hmac('md5', key, Buffer.concat([sid, enc_utc]));
@@ -149,7 +156,7 @@ export default class AutoConfPreset extends IPreset {
     }
     const sid = buffer.slice(0, 2);
     const request_hmac = buffer.slice(6, 22);
-    const key = EVP_BytesToKey(Buffer.from(__KEY__).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
+    const key = EVP_BytesToKey(Buffer.from(this._ctx.KEY).toString('base64') + hash('md5', sid).toString('base64'), 16, 16);
     const hmac_calc = hmac('md5', key, buffer.slice(0, 6));
     if (!hmac_calc.equals(request_hmac)) {
       return fail(`unexpected hmac of client request, dump=${dumpHex(buffer)}`);

--- a/src/presets/defs.js
+++ b/src/presets/defs.js
@@ -120,7 +120,7 @@ export class IPreset {
    * check params passed to the preset, if any errors, should throw directly
    * @param params
    */
-  static checkParams(params) {
+  static checkParams(params, ctx) {
 
   }
 
@@ -128,7 +128,7 @@ export class IPreset {
    * you can make some cache in this function
    * @param params
    */
-  static onInit(params) {
+  static onInit(params, ctx) {
 
   }
 

--- a/src/presets/defs.js
+++ b/src/presets/defs.js
@@ -110,6 +110,13 @@ export class IPreset {
    */
   static checked = false;
 
+
+  /**
+   * server config 
+   * @type {Config}
+   */
+  static config = null;
+
   /**
    * will become true after onInit()
    * @type {boolean}
@@ -120,7 +127,7 @@ export class IPreset {
    * check params passed to the preset, if any errors, should throw directly
    * @param params
    */
-  static checkParams(params, ctx) {
+  static checkParams(params) {
 
   }
 
@@ -128,7 +135,7 @@ export class IPreset {
    * you can make some cache in this function
    * @param params
    */
-  static onInit(params, ctx) {
+  static onInit(params) {
 
   }
 

--- a/src/presets/ss-aead-cipher.js
+++ b/src/presets/ss-aead-cipher.js
@@ -126,13 +126,13 @@ export default class SsAeadCipherPreset extends IPreset {
     }
   }
 
-  static onInit({method}) {
+  static onInit({method}, {KEY}) {
     const [keySize, saltSize, nonceSize] = ciphers[method];
     SsAeadCipherPreset.cipherName = method;
     SsAeadCipherPreset.keySize = keySize;
     SsAeadCipherPreset.saltSize = saltSize;
     SsAeadCipherPreset.nonceSize = nonceSize;
-    SsAeadCipherPreset.evpKey = EVP_BytesToKey(__KEY__, keySize, 16);
+    SsAeadCipherPreset.evpKey = EVP_BytesToKey(KEY, keySize, 16);
     SsAeadCipherPreset.isUseLibSodium = Object.keys(libsodium_functions).includes(method);
   }
 

--- a/src/presets/ss-aead-cipher.js
+++ b/src/presets/ss-aead-cipher.js
@@ -126,13 +126,13 @@ export default class SsAeadCipherPreset extends IPreset {
     }
   }
 
-  static onInit({method}, {KEY}) {
+  static onInit({method}) {
     const [keySize, saltSize, nonceSize] = ciphers[method];
     SsAeadCipherPreset.cipherName = method;
     SsAeadCipherPreset.keySize = keySize;
     SsAeadCipherPreset.saltSize = saltSize;
     SsAeadCipherPreset.nonceSize = nonceSize;
-    SsAeadCipherPreset.evpKey = EVP_BytesToKey(KEY, keySize, 16);
+    SsAeadCipherPreset.evpKey = EVP_BytesToKey(SsAeadCipherPreset.config.key, keySize, 16);
     SsAeadCipherPreset.isUseLibSodium = Object.keys(libsodium_functions).includes(method);
   }
 

--- a/src/presets/ss-base.js
+++ b/src/presets/ss-base.js
@@ -73,6 +73,8 @@ export default class SsBasePreset extends IPresetAddressing {
 
   _headSize = 0;
 
+  _ctx = null;
+
   get headSize() {
     return this._headSize;
   }
@@ -83,8 +85,13 @@ export default class SsBasePreset extends IPresetAddressing {
     this._port = null;
   }
 
+  constructor(_, ctx) {
+    super();
+    this._ctx = ctx;
+  }
+
   onNotified(action) {
-    if (__IS_CLIENT__ && action.type === CONNECT_TO_REMOTE) {
+    if (this._ctx.IS_CLIENT && action.type === CONNECT_TO_REMOTE) {
       const {host, port} = action.payload;
       const type = getHostType(host);
       this._atyp = type;

--- a/src/presets/ss-base.js
+++ b/src/presets/ss-base.js
@@ -73,8 +73,6 @@ export default class SsBasePreset extends IPresetAddressing {
 
   _headSize = 0;
 
-  _ctx = null;
-
   get headSize() {
     return this._headSize;
   }
@@ -85,13 +83,8 @@ export default class SsBasePreset extends IPresetAddressing {
     this._port = null;
   }
 
-  constructor(_, ctx) {
-    super();
-    this._ctx = ctx;
-  }
-
   onNotified(action) {
-    if (this._ctx.IS_CLIENT && action.type === CONNECT_TO_REMOTE) {
+    if (SsBasePreset.config.is_client && action.type === CONNECT_TO_REMOTE) {
       const {host, port} = action.payload;
       const type = getHostType(host);
       this._atyp = type;

--- a/src/presets/ss-stream-cipher.js
+++ b/src/presets/ss-stream-cipher.js
@@ -97,14 +97,14 @@ export default class SsStreamCipherPreset extends IPreset {
     return this._iv;
   }
 
-  constructor({method}, {KEY}) {
+  constructor({method}) {
     super();
     const [keySize, ivSize] = ciphers[method];
     const iv = crypto.randomBytes(ivSize);
     this._algorithm = ['rc4-md5', 'rc4-md5-6'].includes(method) ? 'rc4' : method;
     this._keySize = keySize;
     this._ivSize = ivSize;
-    this._key = EVP_BytesToKey(KEY, keySize, ivSize);
+    this._key = EVP_BytesToKey(SsStreamCipherPreset.config.key, keySize, ivSize);
     this._iv = method === 'rc4-md5-6' ? iv.slice(0, 6) : iv;
   }
 

--- a/src/presets/ss-stream-cipher.js
+++ b/src/presets/ss-stream-cipher.js
@@ -97,14 +97,14 @@ export default class SsStreamCipherPreset extends IPreset {
     return this._iv;
   }
 
-  constructor({method}) {
+  constructor({method}, {KEY}) {
     super();
     const [keySize, ivSize] = ciphers[method];
     const iv = crypto.randomBytes(ivSize);
     this._algorithm = ['rc4-md5', 'rc4-md5-6'].includes(method) ? 'rc4' : method;
     this._keySize = keySize;
     this._ivSize = ivSize;
-    this._key = EVP_BytesToKey(__KEY__, keySize, ivSize);
+    this._key = EVP_BytesToKey(KEY, keySize, ivSize);
     this._iv = method === 'rc4-md5-6' ? iv.slice(0, 6) : iv;
   }
 

--- a/src/presets/ssr-auth-aes128.js
+++ b/src/presets/ssr-auth-aes128.js
@@ -102,8 +102,8 @@ export default class SsrAuthAes128Preset extends IPreset {
 
   _adBuf = null;
 
-  static onInit({KEY}) {
-    SsrAuthAes128Preset.userKey = EVP_BytesToKey(KEY, 16, 16);
+  static onInit() {
+    SsrAuthAes128Preset.userKey = EVP_BytesToKey(SsrAuthAes128Preset.config.key, 16, 16);
     SsrAuthAes128Preset.clientId = crypto.randomBytes(4);
     SsrAuthAes128Preset.connectionId = getRandomInt(0, 0x00ffffff);
   }

--- a/src/presets/ssr-auth-aes128.js
+++ b/src/presets/ssr-auth-aes128.js
@@ -102,8 +102,8 @@ export default class SsrAuthAes128Preset extends IPreset {
 
   _adBuf = null;
 
-  static onInit() {
-    SsrAuthAes128Preset.userKey = EVP_BytesToKey(__KEY__, 16, 16);
+  static onInit({KEY}) {
+    SsrAuthAes128Preset.userKey = EVP_BytesToKey(KEY, 16, 16);
     SsrAuthAes128Preset.clientId = crypto.randomBytes(4);
     SsrAuthAes128Preset.connectionId = getRandomInt(0, 0x00ffffff);
   }

--- a/src/presets/ssr-auth-chain.js
+++ b/src/presets/ssr-auth-chain.js
@@ -143,13 +143,16 @@ export default class SsrAuthChainPreset extends IPreset {
 
   _adBuf = null;
 
+  _ctx = null;
+
   static onInit() {
     SsrAuthChainPreset.clientId = crypto.randomBytes(4);
     SsrAuthChainPreset.connectionId = getRandomInt(0, 0x00ffffff);
   }
 
-  constructor() {
+  constructor(_, ctx) {
     super();
+    this._ctx = ctx;
     this._rngClient = xorshift128plus();
     this._rngServer = xorshift128plus();
     this._adBuf = new AdvancedBuffer({getPacketLength: this.onReceiving.bind(this)});
@@ -232,17 +235,17 @@ export default class SsrAuthChainPreset extends IPreset {
 
   createChunks(buffer) {
     const userKey = this._userKey;
-    const max_payload_size = __IS_CLIENT__ ? 2800 : (this._tcpMss - this._overhead);
+    const max_payload_size = this._ctx.IS_CLIENT ? 2800 : (this._tcpMss - this._overhead);
     return getChunks(buffer, max_payload_size).map((payload) => {
       let _payload = payload;
-      if (__IS_SERVER__ && this._encodeChunkId === 1) {
+      if (this._ctx.IS_SERVER && this._encodeChunkId === 1) {
         _payload = Buffer.concat([ntb(this._tcpMss, 2, BYTE_ORDER_LE), payload]);
       }
       const rc4_enc_payload = this._cipher.update(_payload);
-      const hash = __IS_CLIENT__ ? this._lastClientHash : this._lastServerHash;
+      const hash = this._ctx.IS_CLIENT ? this._lastClientHash : this._lastServerHash;
       const size = rc4_enc_payload.length ^ hash.slice(-2).readUInt16LE(0);
       // generate two pieces of random bytes
-      const rng = __IS_CLIENT__ ? this._rngClient : this._rngServer;
+      const rng = this._ctx.IS_CLIENT ? this._rngClient : this._rngServer;
       const random_bytes_len = this.getRandomBytesLengthForTcp(hash, _payload.length, rng);
       const random_bytes = crypto.randomBytes(random_bytes_len);
       const random_divide_pos = random_bytes_len > 0 ? rng.next().mod(8589934609).mod(random_bytes_len).toNumber() : 0;
@@ -253,7 +256,7 @@ export default class SsrAuthChainPreset extends IPreset {
       const hmac_key = Buffer.concat([userKey, ntb(this._encodeChunkId, 4, BYTE_ORDER_LE)]);
       const chunk_hmac = hmac('md5', hmac_key, chunk);
       chunk = Buffer.concat([chunk, chunk_hmac.slice(0, 2)]);
-      if (__IS_CLIENT__) {
+      if (this._ctx.IS_CLIENT) {
         this._lastClientHash = chunk_hmac;
       } else {
         this._lastServerHash = chunk_hmac;
@@ -350,9 +353,9 @@ export default class SsrAuthChainPreset extends IPreset {
     if (buffer.length < 2 || this._adBuf === null) {
       return; // too short to get size
     }
-    const hash = __IS_CLIENT__ ? this._lastServerHash : this._lastClientHash;
+    const hash = this._ctx.IS_CLIENT ? this._lastServerHash : this._lastClientHash;
     const payload_len = buffer.readUInt16LE(0) ^ hash.readUInt16LE(14);
-    const rng = __IS_CLIENT__ ? this._rngServer : this._rngClient;
+    const rng = this._ctx.IS_CLIENT ? this._rngServer : this._rngClient;
     const random_bytes_len = this.getRandomBytesLengthForTcp(hash, payload_len, rng);
     const chunk_size = 2 + random_bytes_len + payload_len + 2;
     if (chunk_size >= 4096) {
@@ -376,9 +379,9 @@ export default class SsrAuthChainPreset extends IPreset {
       return fail(`unexpected chunk hmac, chunk=${dumpHex(chunk)}`);
     }
     // drop random_bytes, get encrypted payload
-    const hash = __IS_CLIENT__ ? this._lastServerHash : this._lastClientHash;
+    const hash = this._ctx.IS_CLIENT ? this._lastServerHash : this._lastClientHash;
     const payload_len = chunk.readUInt16LE(0) ^ hash.readUInt16LE(14);
-    const rng = __IS_CLIENT__ ? this._rngServer : this._rngClient;
+    const rng = this._ctx.IS_CLIENT ? this._rngServer : this._rngClient;
     const random_bytes_len = this.getRandomBytesLengthForTcp(hash, payload_len, rng);
     let enc_payload = null;
     if (random_bytes_len > 0) {
@@ -390,12 +393,12 @@ export default class SsrAuthChainPreset extends IPreset {
     // decrypt payload
     let payload = this._decipher.update(enc_payload);
     // update hash
-    if (__IS_CLIENT__) {
+    if (this._ctx.IS_CLIENT) {
       this._lastServerHash = new_hash;
     } else {
       this._lastClientHash = new_hash;
     }
-    if (__IS_CLIENT__ && this._decodeChunkId === 1) {
+    if (this._ctx.IS_CLIENT && this._decodeChunkId === 1) {
       this._tcpMss = payload.readUInt16LE(0);
       payload = payload.slice(2);
     }

--- a/src/presets/ssr-auth-chain.js
+++ b/src/presets/ssr-auth-chain.js
@@ -143,16 +143,13 @@ export default class SsrAuthChainPreset extends IPreset {
 
   _adBuf = null;
 
-  _ctx = null;
-
   static onInit() {
     SsrAuthChainPreset.clientId = crypto.randomBytes(4);
     SsrAuthChainPreset.connectionId = getRandomInt(0, 0x00ffffff);
   }
 
-  constructor(_, ctx) {
+  constructor() {
     super();
-    this._ctx = ctx;
     this._rngClient = xorshift128plus();
     this._rngServer = xorshift128plus();
     this._adBuf = new AdvancedBuffer({getPacketLength: this.onReceiving.bind(this)});
@@ -235,17 +232,17 @@ export default class SsrAuthChainPreset extends IPreset {
 
   createChunks(buffer) {
     const userKey = this._userKey;
-    const max_payload_size = this._ctx.IS_CLIENT ? 2800 : (this._tcpMss - this._overhead);
+    const max_payload_size = SsrAuthChainPreset.config.is_client ? 2800 : (this._tcpMss - this._overhead);
     return getChunks(buffer, max_payload_size).map((payload) => {
       let _payload = payload;
-      if (this._ctx.IS_SERVER && this._encodeChunkId === 1) {
+      if (SsrAuthChainPreset.config.is_server && this._encodeChunkId === 1) {
         _payload = Buffer.concat([ntb(this._tcpMss, 2, BYTE_ORDER_LE), payload]);
       }
       const rc4_enc_payload = this._cipher.update(_payload);
-      const hash = this._ctx.IS_CLIENT ? this._lastClientHash : this._lastServerHash;
+      const hash = SsrAuthChainPreset.config.is_client ? this._lastClientHash : this._lastServerHash;
       const size = rc4_enc_payload.length ^ hash.slice(-2).readUInt16LE(0);
       // generate two pieces of random bytes
-      const rng = this._ctx.IS_CLIENT ? this._rngClient : this._rngServer;
+      const rng = SsrAuthChainPreset.config.is_client ? this._rngClient : this._rngServer;
       const random_bytes_len = this.getRandomBytesLengthForTcp(hash, _payload.length, rng);
       const random_bytes = crypto.randomBytes(random_bytes_len);
       const random_divide_pos = random_bytes_len > 0 ? rng.next().mod(8589934609).mod(random_bytes_len).toNumber() : 0;
@@ -256,7 +253,7 @@ export default class SsrAuthChainPreset extends IPreset {
       const hmac_key = Buffer.concat([userKey, ntb(this._encodeChunkId, 4, BYTE_ORDER_LE)]);
       const chunk_hmac = hmac('md5', hmac_key, chunk);
       chunk = Buffer.concat([chunk, chunk_hmac.slice(0, 2)]);
-      if (this._ctx.IS_CLIENT) {
+      if (SsrAuthChainPreset.config.is_client) {
         this._lastClientHash = chunk_hmac;
       } else {
         this._lastServerHash = chunk_hmac;
@@ -353,9 +350,9 @@ export default class SsrAuthChainPreset extends IPreset {
     if (buffer.length < 2 || this._adBuf === null) {
       return; // too short to get size
     }
-    const hash = this._ctx.IS_CLIENT ? this._lastServerHash : this._lastClientHash;
+    const hash = SsrAuthChainPreset.config.is_client ? this._lastServerHash : this._lastClientHash;
     const payload_len = buffer.readUInt16LE(0) ^ hash.readUInt16LE(14);
-    const rng = this._ctx.IS_CLIENT ? this._rngServer : this._rngClient;
+    const rng = SsrAuthChainPreset.config.is_client ? this._rngServer : this._rngClient;
     const random_bytes_len = this.getRandomBytesLengthForTcp(hash, payload_len, rng);
     const chunk_size = 2 + random_bytes_len + payload_len + 2;
     if (chunk_size >= 4096) {
@@ -379,9 +376,9 @@ export default class SsrAuthChainPreset extends IPreset {
       return fail(`unexpected chunk hmac, chunk=${dumpHex(chunk)}`);
     }
     // drop random_bytes, get encrypted payload
-    const hash = this._ctx.IS_CLIENT ? this._lastServerHash : this._lastClientHash;
+    const hash = SsrAuthChainPreset.config.is_client ? this._lastServerHash : this._lastClientHash;
     const payload_len = chunk.readUInt16LE(0) ^ hash.readUInt16LE(14);
-    const rng = this._ctx.IS_CLIENT ? this._rngServer : this._rngClient;
+    const rng = SsrAuthChainPreset.config.is_client ? this._rngServer : this._rngClient;
     const random_bytes_len = this.getRandomBytesLengthForTcp(hash, payload_len, rng);
     let enc_payload = null;
     if (random_bytes_len > 0) {
@@ -393,12 +390,12 @@ export default class SsrAuthChainPreset extends IPreset {
     // decrypt payload
     let payload = this._decipher.update(enc_payload);
     // update hash
-    if (this._ctx.IS_CLIENT) {
+    if (SsrAuthChainPreset.config.is_client) {
       this._lastServerHash = new_hash;
     } else {
       this._lastClientHash = new_hash;
     }
-    if (this._ctx.IS_CLIENT && this._decodeChunkId === 1) {
+    if (SsrAuthChainPreset.config.is_client && this._decodeChunkId === 1) {
       this._tcpMss = payload.readUInt16LE(0);
       payload = payload.slice(2);
     }

--- a/src/presets/tracker.js
+++ b/src/presets/tracker.js
@@ -29,13 +29,6 @@ export default class TrackerPreset extends IPreset {
   _targetHost;
   _targetPort;
 
-  _ctx = null;
-
-  constructor(_, ctx) {
-    super();
-    this._ctx = ctx;
-  }
-
   onNotified({type, payload}) {
     switch (type) {
       case CONNECTION_CREATED: {
@@ -102,7 +95,7 @@ export default class TrackerPreset extends IPreset {
     if (strs.length > TRACK_MAX_SIZE) {
       strs = strs.slice(0, perSize).concat([' ... ']).concat(strs.slice(-perSize));
     }
-    const summary = this._ctx.IS_CLIENT ? `out/in = ${up}/${dp}, ${ub}b/${db}b` : `in/out = ${dp}/${up}, ${db}b/${ub}b`;
+    const summary = TrackerPreset.config.is_client ? `out/in = ${up}/${dp}, ${ub}b/${db}b` : `in/out = ${dp}/${up}, ${db}b/${ub}b`;
     logger.info(`[tracker:${this._transport}] summary(${summary}) abstract(${strs.join(' ')})`);
   }
 

--- a/src/presets/tracker.js
+++ b/src/presets/tracker.js
@@ -29,6 +29,13 @@ export default class TrackerPreset extends IPreset {
   _targetHost;
   _targetPort;
 
+  _ctx = null;
+
+  constructor(_, ctx) {
+    super();
+    this._ctx = ctx;
+  }
+
   onNotified({type, payload}) {
     switch (type) {
       case CONNECTION_CREATED: {
@@ -95,7 +102,7 @@ export default class TrackerPreset extends IPreset {
     if (strs.length > TRACK_MAX_SIZE) {
       strs = strs.slice(0, perSize).concat([' ... ']).concat(strs.slice(-perSize));
     }
-    const summary = __IS_CLIENT__ ? `out/in = ${up}/${dp}, ${ub}b/${db}b` : `in/out = ${dp}/${up}, ${db}b/${ub}b`;
+    const summary = this._ctx.IS_CLIENT ? `out/in = ${up}/${dp}, ${ub}b/${db}b` : `in/out = ${dp}/${up}, ${db}b/${ub}b`;
     logger.info(`[tracker:${this._transport}] summary(${summary}) abstract(${strs.join(' ')})`);
   }
 

--- a/src/presets/v2ray-vmess.js
+++ b/src/presets/v2ray-vmess.js
@@ -192,6 +192,8 @@ export default class V2rayVmessPreset extends IPresetAddressing {
   _cipherNonce = 0;
   _decipherNonce = 0;
 
+  _ctx = null;
+
   static checkParams({id, security = 'aes-128-gcm'}) {
     if (Buffer.from(id.split('-').join(''), 'hex').length !== 16) {
       throw Error('id is not a valid uuid');
@@ -202,9 +204,9 @@ export default class V2rayVmessPreset extends IPresetAddressing {
     }
   }
 
-  static onInit({id, security = 'aes-128-gcm'}) {
+  static onInit({id, security = 'aes-128-gcm'}, {IS_CLIENT}) {
     V2rayVmessPreset.uuid = Buffer.from(id.split('-').join(''), 'hex');
-    if (__IS_CLIENT__) {
+    if (IS_CLIENT) {
       V2rayVmessPreset.security = securityTypes[security];
     }
     setInterval(() => V2rayVmessPreset.updateAuthCache(), 1e3);
@@ -231,8 +233,9 @@ export default class V2rayVmessPreset extends IPresetAddressing {
     this.userHashCache = newItems;
   }
 
-  constructor() {
+  constructor(_, ctx) {
     super();
+    this._ctx = ctx;
     this._adBuf = new AdvancedBuffer({getPacketLength: this.onReceiving.bind(this)});
     this._adBuf.on('data', this.onChunkReceived.bind(this));
   }
@@ -254,7 +257,7 @@ export default class V2rayVmessPreset extends IPresetAddressing {
   }
 
   onNotified(action) {
-    if (__IS_CLIENT__ && action.type === CONNECT_TO_REMOTE) {
+    if (this._ctx.IS_CLIENT && action.type === CONNECT_TO_REMOTE) {
       const {host, port} = action.payload;
       const type = getAddrType(host);
       this._atyp = type;
@@ -269,7 +272,7 @@ export default class V2rayVmessPreset extends IPresetAddressing {
   beforeOut({buffer}) {
     if (!this._isHeaderSent) {
       this._isHeaderSent = true;
-      const header = __IS_CLIENT__ ? this.createRequestHeader() : this.createResponseHeader();
+      const header = this._ctx.IS_CLIENT ? this.createRequestHeader() : this.createResponseHeader();
       const chunks = this.getBufferChunks(buffer);
       return Buffer.concat([header, ...chunks]);
     } else {

--- a/src/transports/defs.js
+++ b/src/transports/defs.js
@@ -5,12 +5,12 @@ import EventEmitter from 'events';
 class Bound extends EventEmitter {
 
   _ctx = null;
-  _globalCtx = null;
+  _config = null;
 
-  constructor({context, globalContext}) {
+  constructor({context, config}) {
     super();
     this._ctx = context;
-    this._globalCtx = globalContext;
+    this._config = config;
   }
 
   get ctx() {

--- a/src/transports/defs.js
+++ b/src/transports/defs.js
@@ -5,10 +5,12 @@ import EventEmitter from 'events';
 class Bound extends EventEmitter {
 
   _ctx = null;
+  _globalCtx = null;
 
-  constructor({context}) {
+  constructor({context, globalContext}) {
     super();
     this._ctx = context;
+    this._globalCtx = globalContext;
   }
 
   get ctx() {

--- a/src/transports/mux.js
+++ b/src/transports/mux.js
@@ -7,7 +7,7 @@ export class MuxInbound extends Inbound {
   constructor(props) {
     super(props);
     this.onDrain = this.onDrain.bind(this);
-    if (this._globalCtx.IS_SERVER) {
+    if (this._config.is_server) {
       const inbound = this.ctx.muxRelay.getInbound();
       inbound.on('drain', this.onDrain);
     } else {
@@ -20,7 +20,7 @@ export class MuxInbound extends Inbound {
   }
 
   get bufferSize() {
-    if (this._globalCtx.IS_CLIENT) {
+    if (this._config.is_client) {
       const totalBufferSize = 0;
       // const subRelays = this.ctx.thisRelay.getSubRelays();
       // if (subRelays) {
@@ -70,7 +70,7 @@ export class MuxInbound extends Inbound {
   }
 
   write(buffer) {
-    if (this._globalCtx.IS_SERVER) {
+    if (this._config.is_server) {
       const {muxRelay, cid} = this.ctx;
       muxRelay.encode(buffer, {cid});
     }
@@ -83,7 +83,7 @@ export class MuxInbound extends Inbound {
 
   close() {
     const doClose = () => {
-      if (this._globalCtx.IS_SERVER) {
+      if (this._config.is_server) {
         const {muxRelay, cid} = this.ctx;
         const inbound = muxRelay.getInbound();
         if (inbound) {
@@ -112,7 +112,7 @@ export class MuxOutbound extends Outbound {
   constructor(props) {
     super(props);
     this.onDrain = this.onDrain.bind(this);
-    if (this._globalCtx.IS_CLIENT) {
+    if (this._config.is_client) {
       const outbound = this.ctx.muxRelay.getOutbound();
       outbound.on('drain', this.onDrain);
     } else {
@@ -121,7 +121,7 @@ export class MuxOutbound extends Outbound {
   }
 
   get bufferSize() {
-    if (this._globalCtx.IS_CLIENT) {
+    if (this._config.is_client) {
       const outbound = this.ctx.muxRelay.getOutbound();
       if (outbound) {
         return outbound.bufferSize;
@@ -148,7 +148,7 @@ export class MuxOutbound extends Outbound {
   }
 
   write(buffer) {
-    if (this._globalCtx.IS_CLIENT) {
+    if (this._config.is_client) {
       const {muxRelay, proxyRequest, cid} = this.ctx;
       if (this._isFirstFrame) {
         this._isFirstFrame = false;
@@ -166,7 +166,7 @@ export class MuxOutbound extends Outbound {
 
   close() {
     const doClose = () => {
-      if (this._globalCtx.IS_CLIENT) {
+      if (this._config.is_client) {
         const {muxRelay, cid} = this.ctx;
         const outbound = muxRelay.getOutbound();
         if (outbound) {

--- a/src/transports/mux.js
+++ b/src/transports/mux.js
@@ -7,7 +7,7 @@ export class MuxInbound extends Inbound {
   constructor(props) {
     super(props);
     this.onDrain = this.onDrain.bind(this);
-    if (__IS_SERVER__) {
+    if (this._globalCtx.IS_SERVER) {
       const inbound = this.ctx.muxRelay.getInbound();
       inbound.on('drain', this.onDrain);
     } else {
@@ -20,7 +20,7 @@ export class MuxInbound extends Inbound {
   }
 
   get bufferSize() {
-    if (__IS_CLIENT__) {
+    if (this._globalCtx.IS_CLIENT) {
       const totalBufferSize = 0;
       // const subRelays = this.ctx.thisRelay.getSubRelays();
       // if (subRelays) {
@@ -70,7 +70,7 @@ export class MuxInbound extends Inbound {
   }
 
   write(buffer) {
-    if (__IS_SERVER__) {
+    if (this._globalCtx.IS_SERVER) {
       const {muxRelay, cid} = this.ctx;
       muxRelay.encode(buffer, {cid});
     }
@@ -83,7 +83,7 @@ export class MuxInbound extends Inbound {
 
   close() {
     const doClose = () => {
-      if (__IS_SERVER__) {
+      if (this._globalCtx.IS_SERVER) {
         const {muxRelay, cid} = this.ctx;
         const inbound = muxRelay.getInbound();
         if (inbound) {
@@ -112,7 +112,7 @@ export class MuxOutbound extends Outbound {
   constructor(props) {
     super(props);
     this.onDrain = this.onDrain.bind(this);
-    if (__IS_CLIENT__) {
+    if (this._globalCtx.IS_CLIENT) {
       const outbound = this.ctx.muxRelay.getOutbound();
       outbound.on('drain', this.onDrain);
     } else {
@@ -121,7 +121,7 @@ export class MuxOutbound extends Outbound {
   }
 
   get bufferSize() {
-    if (__IS_CLIENT__) {
+    if (this._globalCtx.IS_CLIENT) {
       const outbound = this.ctx.muxRelay.getOutbound();
       if (outbound) {
         return outbound.bufferSize;
@@ -148,7 +148,7 @@ export class MuxOutbound extends Outbound {
   }
 
   write(buffer) {
-    if (__IS_CLIENT__) {
+    if (this._globalCtx.IS_CLIENT) {
       const {muxRelay, proxyRequest, cid} = this.ctx;
       if (this._isFirstFrame) {
         this._isFirstFrame = false;
@@ -166,7 +166,7 @@ export class MuxOutbound extends Outbound {
 
   close() {
     const doClose = () => {
-      if (__IS_CLIENT__) {
+      if (this._globalCtx.IS_CLIENT) {
         const {muxRelay, cid} = this.ctx;
         const outbound = muxRelay.getOutbound();
         if (outbound) {

--- a/src/transports/tls.js
+++ b/src/transports/tls.js
@@ -29,7 +29,7 @@ export class TlsOutbound extends TcpOutbound {
   // overwrite _connect of tcp outbound using tls.connect()
   async _connect({host, port}) {
     logger.info(`[tls:outbound] [${this.remote}] connecting to tls://${host}:${port}`);
-    return tls.connect({host, port, ca: [this._globalCtx.TLS_CERT]});
+    return tls.connect({host, port, ca: [this._config.tls_cert]});
   }
 
 }

--- a/src/transports/tls.js
+++ b/src/transports/tls.js
@@ -29,7 +29,7 @@ export class TlsOutbound extends TcpOutbound {
   // overwrite _connect of tcp outbound using tls.connect()
   async _connect({host, port}) {
     logger.info(`[tls:outbound] [${this.remote}] connecting to tls://${host}:${port}`);
-    return tls.connect({host, port, ca: [__TLS_CERT__]});
+    return tls.connect({host, port, ca: [this._globalCtx.TLS_CERT]});
   }
 
 }

--- a/src/transports/udp.js
+++ b/src/transports/udp.js
@@ -18,7 +18,7 @@ export class UdpInbound extends Inbound {
   }
 
   onReceive(buffer, rinfo) {
-    const type = this._globalCtx.IS_CLIENT ? PIPE_ENCODE : PIPE_DECODE;
+    const type = this._config.is_client ? PIPE_ENCODE : PIPE_DECODE;
     this._rinfo = rinfo;
     this.ctx.pipe.feed(type, buffer);
   }
@@ -51,7 +51,7 @@ export class UdpInbound extends Inbound {
         logger.warn(`[udp:inbound] [${this.remote}]:`, err);
       }
     };
-    if (this._globalCtx.IS_CLIENT) {
+    if (this._config.is_client) {
       const isSs = this.ctx.pipe.presets.some(({name}) => ['ss-base'].includes(name));
       this._socket.send(buffer, port, address, isSs, onSendError);
     } else {
@@ -85,7 +85,7 @@ export class UdpOutbound extends Outbound {
   }
 
   onReceive(buffer) {
-    const type = this._globalCtx.IS_CLIENT ? PIPE_DECODE : PIPE_ENCODE;
+    const type = this._config.is_client ? PIPE_DECODE : PIPE_ENCODE;
     this.ctx.pipe.feed(type, buffer);
   }
 
@@ -121,11 +121,11 @@ export class UdpOutbound extends Outbound {
 
   onConnectToRemote(action) {
     const {host, port, onConnected} = action.payload;
-    if (this._globalCtx.IS_CLIENT) {
-      this._targetHost = this._globalCtx.SERVER_HOST;
-      this._targetPort = this._globalCtx.SERVER_PORT;
+    if (this._config.is_client) {
+      this._targetHost = this._config.server_host;
+      this._targetPort = this._config.server_port;
     }
-    if (this._globalCtx.IS_SERVER) {
+    if (this._config.is_server) {
       this._targetHost = host;
       this._targetPort = port;
       if (typeof onConnected === 'function') {

--- a/src/transports/udp.js
+++ b/src/transports/udp.js
@@ -18,7 +18,7 @@ export class UdpInbound extends Inbound {
   }
 
   onReceive(buffer, rinfo) {
-    const type = __IS_CLIENT__ ? PIPE_ENCODE : PIPE_DECODE;
+    const type = this._globalCtx.IS_CLIENT ? PIPE_ENCODE : PIPE_DECODE;
     this._rinfo = rinfo;
     this.ctx.pipe.feed(type, buffer);
   }
@@ -51,7 +51,7 @@ export class UdpInbound extends Inbound {
         logger.warn(`[udp:inbound] [${this.remote}]:`, err);
       }
     };
-    if (__IS_CLIENT__) {
+    if (this._globalCtx.IS_CLIENT) {
       const isSs = this.ctx.pipe.presets.some(({name}) => ['ss-base'].includes(name));
       this._socket.send(buffer, port, address, isSs, onSendError);
     } else {
@@ -85,7 +85,7 @@ export class UdpOutbound extends Outbound {
   }
 
   onReceive(buffer) {
-    const type = __IS_CLIENT__ ? PIPE_DECODE : PIPE_ENCODE;
+    const type = this._globalCtx.IS_CLIENT ? PIPE_DECODE : PIPE_ENCODE;
     this.ctx.pipe.feed(type, buffer);
   }
 
@@ -121,11 +121,11 @@ export class UdpOutbound extends Outbound {
 
   onConnectToRemote(action) {
     const {host, port, onConnected} = action.payload;
-    if (__IS_CLIENT__) {
-      this._targetHost = __SERVER_HOST__;
-      this._targetPort = __SERVER_PORT__;
+    if (this._globalCtx.IS_CLIENT) {
+      this._targetHost = this._globalCtx.SERVER_HOST;
+      this._targetPort = this._globalCtx.SERVER_PORT;
     }
-    if (__IS_SERVER__) {
+    if (this._globalCtx.IS_SERVER) {
       this._targetHost = host;
       this._targetPort = port;
       if (typeof onConnected === 'function') {

--- a/test/common/preset-runner.js
+++ b/test/common/preset-runner.js
@@ -5,13 +5,15 @@ import {Middleware} from '../../src/core/middleware';
 
 
 export class PresetRunner extends EventEmitter {
-  _ctx = null;
+  _config = null;
 
-  constructor({name, params = {}}, context = {}) {
+  constructor({name, params = {}}, config = {}) {
     super();
-    this._ctx = context;
-    getPresetClassByName(name).checkParams(params);
-    this.middleware = new Middleware({name, params}, context);
+    this._config = config;
+    const clazz = getPresetClassByName(name);
+    clazz.config = config;
+    clazz.checkParams(params);
+    this.middleware = new Middleware({name, params}, config);
   }
 
   notify(action) {
@@ -32,7 +34,7 @@ export class PresetRunner extends EventEmitter {
       this.middleware.on('fail', reject);
       this.middleware.on('broadcast', (name, action) => this.emit('broadcast', action));
       this.middleware.write({
-        direction: this._ctx.IS_CLIENT ? PIPE_ENCODE : PIPE_DECODE,
+        direction: this._config.is_client ? PIPE_ENCODE : PIPE_DECODE,
         buffer: data,
         direct: resolve,
         isUdp
@@ -50,7 +52,7 @@ export class PresetRunner extends EventEmitter {
       this.middleware.on('fail', reject);
       this.middleware.on('broadcast', (name, action) => this.emit('broadcast', action));
       this.middleware.write({
-        direction: this._ctx.IS_CLIENT ? PIPE_DECODE : PIPE_ENCODE,
+        direction: this._config.is_client ? PIPE_DECODE : PIPE_ENCODE,
         buffer: data,
         direct: resolve,
         isUdp

--- a/test/common/preset-runner.js
+++ b/test/common/preset-runner.js
@@ -3,17 +3,15 @@ import {getPresetClassByName} from '../../src/presets';
 import {PIPE_ENCODE, PIPE_DECODE} from '../../src/constants';
 import {Middleware} from '../../src/core/middleware';
 
-export function setGlobals(obj) {
-  Object.assign(global, obj);
-}
 
 export class PresetRunner extends EventEmitter {
+  _ctx = null;
 
-  constructor({name, params = {}}, globals = {}) {
+  constructor({name, params = {}}, context = {}) {
     super();
-    setGlobals(globals);
+    this._ctx = context;
     getPresetClassByName(name).checkParams(params);
-    this.middleware = new Middleware({name, params});
+    this.middleware = new Middleware({name, params}, context);
   }
 
   notify(action) {
@@ -34,7 +32,7 @@ export class PresetRunner extends EventEmitter {
       this.middleware.on('fail', reject);
       this.middleware.on('broadcast', (name, action) => this.emit('broadcast', action));
       this.middleware.write({
-        direction: __IS_CLIENT__ ? PIPE_ENCODE : PIPE_DECODE,
+        direction: this._ctx.IS_CLIENT ? PIPE_ENCODE : PIPE_DECODE,
         buffer: data,
         direct: resolve,
         isUdp
@@ -52,7 +50,7 @@ export class PresetRunner extends EventEmitter {
       this.middleware.on('fail', reject);
       this.middleware.on('broadcast', (name, action) => this.emit('broadcast', action));
       this.middleware.write({
-        direction: __IS_CLIENT__ ? PIPE_DECODE : PIPE_ENCODE,
+        direction: this._ctx.IS_CLIENT ? PIPE_DECODE : PIPE_ENCODE,
         buffer: data,
         direct: resolve,
         isUdp

--- a/test/presets/access-control.test.js
+++ b/test/presets/access-control.test.js
@@ -14,8 +14,8 @@ test('running on both client and server', async () => {
       acl: path.join(__dirname, 'acl.txt')
     }
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   await sleep(20);

--- a/test/presets/access-control.test.js
+++ b/test/presets/access-control.test.js
@@ -14,8 +14,8 @@ test('running on both client and server', async () => {
       acl: path.join(__dirname, 'acl.txt')
     }
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   await sleep(20);

--- a/test/presets/aead-random-cipher.test.js
+++ b/test/presets/aead-random-cipher.test.js
@@ -7,9 +7,9 @@ test('running on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   const packet_1 = await runner.forward('12');

--- a/test/presets/aead-random-cipher.test.js
+++ b/test/presets/aead-random-cipher.test.js
@@ -7,9 +7,9 @@ test('running on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   const packet_1 = await runner.forward('12');

--- a/test/presets/base-auth.test.js
+++ b/test/presets/base-auth.test.js
@@ -5,9 +5,9 @@ test('tcp relay on client and server', async () => {
   let runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   // client
@@ -36,9 +36,9 @@ test('tcp relay on client and server', async () => {
   runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: false,
-    __IS_SERVER__: true
+    KEY: 'secret',
+    IS_CLIENT: false,
+    IS_SERVER: true
   });
 
   runner.on('broadcast', (action) => {
@@ -61,9 +61,9 @@ test('udp relay on client and server', async () => {
   let runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   // client
@@ -86,9 +86,9 @@ test('udp relay on client and server', async () => {
   runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: false,
-    __IS_SERVER__: true
+    KEY: 'secret',
+    IS_CLIENT: false,
+    IS_SERVER: true
   });
 
   runner.on('broadcast', (action) => {

--- a/test/presets/base-auth.test.js
+++ b/test/presets/base-auth.test.js
@@ -5,9 +5,9 @@ test('tcp relay on client and server', async () => {
   let runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   // client
@@ -36,9 +36,9 @@ test('tcp relay on client and server', async () => {
   runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    KEY: 'secret',
-    IS_CLIENT: false,
-    IS_SERVER: true
+    key: 'secret',
+    is_client: false,
+    is_server: true
   });
 
   runner.on('broadcast', (action) => {
@@ -61,9 +61,9 @@ test('udp relay on client and server', async () => {
   let runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   // client
@@ -86,9 +86,9 @@ test('udp relay on client and server', async () => {
   runner = new PresetRunner({
     name: 'base-auth'
   }, {
-    KEY: 'secret',
-    IS_CLIENT: false,
-    IS_SERVER: true
+    key: 'secret',
+    is_client: false,
+    is_server: true
   });
 
   runner.on('broadcast', (action) => {

--- a/test/presets/obfs-random-padding.test.js
+++ b/test/presets/obfs-random-padding.test.js
@@ -4,8 +4,8 @@ test('running on both client and server', async () => {
   const runner = new PresetRunner({
     name: 'obfs-random-padding'
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   const chunk = await runner.forward('12');

--- a/test/presets/obfs-random-padding.test.js
+++ b/test/presets/obfs-random-padding.test.js
@@ -4,8 +4,8 @@ test('running on both client and server', async () => {
   const runner = new PresetRunner({
     name: 'obfs-random-padding'
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   const chunk = await runner.forward('12');

--- a/test/presets/ss-aead-cipher.test.js
+++ b/test/presets/ss-aead-cipher.test.js
@@ -7,9 +7,9 @@ test('tcp relay on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_serevr: false
   });
 
   const packet_1 = await runner.forward('12');
@@ -38,9 +38,9 @@ test('udp relay on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   const packet = await runner.forwardUdp('12');

--- a/test/presets/ss-aead-cipher.test.js
+++ b/test/presets/ss-aead-cipher.test.js
@@ -7,9 +7,9 @@ test('tcp relay on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   const packet_1 = await runner.forward('12');
@@ -38,9 +38,9 @@ test('udp relay on client and server', async () => {
       method: 'aes-128-gcm'
     }
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   const packet = await runner.forwardUdp('12');

--- a/test/presets/ss-base.test.js
+++ b/test/presets/ss-base.test.js
@@ -5,8 +5,8 @@ test('running on client', async () => {
   const runner = new PresetRunner({
     name: 'ss-base'
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   runner.notify({
@@ -40,8 +40,8 @@ test('running on server', async () => {
     const runner = new PresetRunner({
       name: 'ss-base'
     }, {
-      IS_CLIENT: false,
-      IS_SERVER: true
+      is_client: false,
+      is_server: true
     });
 
     runner.on('broadcast', (action) => {

--- a/test/presets/ss-base.test.js
+++ b/test/presets/ss-base.test.js
@@ -5,8 +5,8 @@ test('running on client', async () => {
   const runner = new PresetRunner({
     name: 'ss-base'
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   runner.notify({
@@ -40,8 +40,8 @@ test('running on server', async () => {
     const runner = new PresetRunner({
       name: 'ss-base'
     }, {
-      __IS_CLIENT__: false,
-      __IS_SERVER__: true
+      IS_CLIENT: false,
+      IS_SERVER: true
     });
 
     runner.on('broadcast', (action) => {

--- a/test/presets/ss-stream-cipher.test.js
+++ b/test/presets/ss-stream-cipher.test.js
@@ -7,9 +7,9 @@ test('tcp relay on client and server', async () => {
       method: 'aes-128-ctr'
     }
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   // should add 16 more bytes at the beginning
@@ -35,9 +35,9 @@ test('udp relay on client and server', async () => {
       method: 'rc4-md5-6'
     }
   }, {
-    __KEY__: 'secret',
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    KEY: 'secret',
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   expect(await runner.forwardUdp('1')).toHaveLength(6 + 1);

--- a/test/presets/ss-stream-cipher.test.js
+++ b/test/presets/ss-stream-cipher.test.js
@@ -7,9 +7,9 @@ test('tcp relay on client and server', async () => {
       method: 'aes-128-ctr'
     }
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   // should add 16 more bytes at the beginning
@@ -35,9 +35,9 @@ test('udp relay on client and server', async () => {
       method: 'rc4-md5-6'
     }
   }, {
-    KEY: 'secret',
-    IS_CLIENT: true,
-    IS_SERVER: false
+    key: 'secret',
+    is_client: true,
+    is_server: false
   });
 
   expect(await runner.forwardUdp('1')).toHaveLength(6 + 1);

--- a/test/presets/stats.test.js
+++ b/test/presets/stats.test.js
@@ -13,8 +13,8 @@ test('running on both client and server', async () => {
       save_interval: 1
     }
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   runner.notify({type: CONNECTION_CREATED});

--- a/test/presets/stats.test.js
+++ b/test/presets/stats.test.js
@@ -13,8 +13,8 @@ test('running on both client and server', async () => {
       save_interval: 1
     }
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   runner.notify({type: CONNECTION_CREATED});

--- a/test/presets/tracker.test.js
+++ b/test/presets/tracker.test.js
@@ -5,8 +5,8 @@ test('tcp relay on client and server', async () => {
   const runner = new PresetRunner({
     name: 'tracker'
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   const actionPayload = {
@@ -33,8 +33,8 @@ test('udp relay on client and server', async () => {
   const runner = new PresetRunner({
     name: 'tracker'
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   expect(await runner.forwardUdp('12')).toMatchSnapshot();

--- a/test/presets/tracker.test.js
+++ b/test/presets/tracker.test.js
@@ -5,8 +5,8 @@ test('tcp relay on client and server', async () => {
   const runner = new PresetRunner({
     name: 'tracker'
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   const actionPayload = {
@@ -33,8 +33,8 @@ test('udp relay on client and server', async () => {
   const runner = new PresetRunner({
     name: 'tracker'
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   expect(await runner.forwardUdp('12')).toMatchSnapshot();

--- a/test/presets/v2ray-vmess.test.js
+++ b/test/presets/v2ray-vmess.test.js
@@ -9,8 +9,8 @@ test('running on client', async () => {
       security: 'aes-128-gcm'
     }
   }, {
-    IS_CLIENT: true,
-    IS_SERVER: false
+    is_client: true,
+    is_server: false
   });
 
   runner.notify({
@@ -40,8 +40,8 @@ test('running on server', async () => {
       id: 'a3482e88-686a-4a58-8126-99c9df64b7bf'
     }
   }, {
-    IS_CLIENT: false,
-    IS_SERVER: true
+    is_client: false,
+    is_server: true
   });
 
   // fail on wrong data

--- a/test/presets/v2ray-vmess.test.js
+++ b/test/presets/v2ray-vmess.test.js
@@ -9,8 +9,8 @@ test('running on client', async () => {
       security: 'aes-128-gcm'
     }
   }, {
-    __IS_CLIENT__: true,
-    __IS_SERVER__: false
+    IS_CLIENT: true,
+    IS_SERVER: false
   });
 
   runner.notify({
@@ -40,8 +40,8 @@ test('running on server', async () => {
       id: 'a3482e88-686a-4a58-8126-99c9df64b7bf'
     }
   }, {
-    __IS_CLIENT__: false,
-    __IS_SERVER__: true
+    IS_CLIENT: false,
+    IS_SERVER: true
   });
 
   // fail on wrong data


### PR DESCRIPTION
在现在这个版本, 每创建一次 `Hub` 会将全局变量设置为当前这个配置文件
我现在想实现多用户服务端(shadowsocks manyuser)的时候就出现了问题 每创建一个服务端的时候都会覆盖一遍全局变量 

```js
const blinksocks = require('blinksocks');
const configs = [
  {
    service: 'tcp://0.0.0.0:1082',
    key: 'Password',
    presets: [{
      'name': 'ss-base'
    }, {
      'name': 'ss-stream-cipher',
      'params': {
        'method': 'aes-128-ctr'
      }
    }]
  }, {
    service: 'tcp://0.0.0.0:1355',
    key: 'Password2',
    presets: [{
      'name': 'ss-base'
    }, {
      'name': 'ss-stream-cipher',
      'params': {
        'method': 'aes-128-ctr'
      }
    }]
  }
];

const hubs = [];
for (const config of configs) {
  const hub = new blinksocks.Hub(config)
  hub.run()
  hubs.push(hub)
}
```
这时候就会出现
```plain
info: [hub-0] blinksocks server is running at tcp://0.0.0.0:1082
info: [hub-0] blinksocks server is running at tcp://0.0.0.0:1355
info: [hub-0] blinksocks udp server is running at udp://0.0.0.0:1355
info: [hub-0] blinksocks udp server is running at udp://0.0.0.0:1355
error: [hub] fail to create server: Error: bind EADDRINUSE 0.0.0.0:1355
    at Object._errnoException (util.js:1026:11)
    at _exceptionWithHostPort (util.js:1049:20)
    at _handle.lookup (dgram.js:242:18)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:667:11)
    at startup (bootstrap_node.js:201:16)
    at bootstrap_node.js:626:3
```

我尝试将配置文件包成一个上下文而不是通过global来交换数据来解决这个问题（